### PR TITLE
Implement non-mut iterator for collections

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,13 @@
 //!     /// * `fn get_mut(&mut self, idx: usize) -> Option<Self::Mut>`
 //!     collection trait RgbCollection;
 //!
+//!     /// Iterator struct for collection.
+//!     ///
+//!     /// Generated trait method for Iterator:
+//!     ///
+//!     /// * `fn next(&mut self) -> Option<Self::Item>`
+//!     iterator struct RgbCollectionIterator;
+//!
 //!     /// A trait for anything that is logically an immutable, shared
 //!     /// reference to an `Rgb`.
 //!     ///
@@ -120,6 +127,9 @@ macro_rules! aossoa {
 
         $( #[$trait_attr:meta] )*
         collection trait $collection_trait_name:ident ;
+
+        $( #[$iterator_struct_attr:meta] )*
+        iterator struct $iterator_struct_name:ident ;
 
         $( #[$ref_trait_attr:meta] )*
         ref trait $ref_trait_name:ident ;
@@ -223,8 +233,9 @@ macro_rules! aossoa {
             /// or `None` if the index is out of bounds.
             fn get_mut(&'a mut self, idx: usize) -> Option<Self::Mut>;
 
-            // /// TODO FITZGEN
-            // fn iter(&'a self) -> Self::Iter;
+            fn iter(&'a self) -> $iterator_struct_name <'a, Self> {
+                $iterator_struct_name::<'a, Self> { collection: &self, index: 0}
+            }
 
             // /// TODO FITZGEN
             // fn iter_mut(&'a mut self) -> Self::IterMut;
@@ -244,6 +255,29 @@ macro_rules! aossoa {
             $(
                 fn $field_name (&mut self) -> &mut $field_ty;
             )*
+        }
+
+        // Iterator ////////////////////////////////////////////////////////////
+
+        pub struct $iterator_struct_name<'a, T>
+            where T: 'a + $collection_trait_name<'a>
+        {
+            collection: &'a T,
+            index: usize,
+        }
+
+        impl<'a, T> Iterator for $iterator_struct_name<'a, T>
+            where T: 'a + $collection_trait_name<'a>
+        {
+            type Item = T::Ref;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                let value = self.collection.get(self.index);
+                // TODO: We could probably reuse the index in the Ref type somehow
+                //       Possibly by making the Ref type the iterator
+                self.index += 1;
+                value
+            }
         }
 
         // AOS /////////////////////////////////////////////////////////////////
@@ -509,6 +543,7 @@ mod tests {
         }
 
         collection trait RgbCollection;
+        iterator struct RgbCollectionIterator;
         ref trait RgbRef;
         ref mut trait RgbRefMut;
 
@@ -537,6 +572,16 @@ mod tests {
         sum
     }
 
+    fn sum_all_rgb_iter<'a, T: RgbCollection<'a>>(rgbs: &'a T) -> usize {
+        let mut sum = 0;
+        for rgb in rgbs.iter() {
+            sum += *rgb.r() as usize;
+            sum += *rgb.g() as usize;
+            sum += *rgb.b() as usize;
+        }
+        sum
+    }
+
     #[test]
     fn sum_all_rgb_test() {
         let aos = RgbAos::from_iter([
@@ -559,5 +604,7 @@ mod tests {
 
         assert_eq!(sum_all_rgb(&aos), 36);
         assert_eq!(sum_all_rgb(&soa), 36);
+        assert_eq!(sum_all_rgb_iter(&aos), 36);
+        assert_eq!(sum_all_rgb_iter(&soa), 36);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,8 +233,12 @@ macro_rules! aossoa {
             /// or `None` if the index is out of bounds.
             fn get_mut(&'a mut self, idx: usize) -> Option<Self::Mut>;
 
+            /// Provides a forward iterator.
             fn iter(&'a self) -> $iterator_struct_name <'a, Self> {
-                $iterator_struct_name::<'a, Self> { collection: &self, index: 0}
+                $iterator_struct_name::<'a, Self> {
+                    collection: &self,
+                    index: 0,
+                }
             }
 
             // /// TODO FITZGEN
@@ -273,8 +277,6 @@ macro_rules! aossoa {
 
             fn next(&mut self) -> Option<Self::Item> {
                 let value = self.collection.get(self.index);
-                // TODO: We could probably reuse the index in the Ref type somehow
-                //       Possibly by making the Ref type the iterator
                 self.index += 1;
                 value
             }


### PR DESCRIPTION
Next steps:

- mut iterator
- possibly reusing index in Ref type of Ref type itself as an iterator
- figure out how the associated Iter type should be implemented
- verify that the compiler can actually turn this into fast code

Co-authored by Ben.